### PR TITLE
CRM-14226 getMenu() should not be called statically

### DIFF
--- a/site/civicrm.php
+++ b/site/civicrm.php
@@ -58,7 +58,7 @@ function civicrm_invoke() {
   // overrride the GET values if conflict
   if (!empty($_REQUEST['Itemid'])) {
     $component = JComponentHelper::getComponent('com_civicrm');
-    $menu      = JSite::getMenu();
+    $menu      = JFactory::getApplication()->getMenu();
     $params    = $menu->getParams($_REQUEST['Itemid']);
     $args      = array('task', 'id', 'gid', 'pageId', 'action', 'csid', 'component');
     $view      = CRM_Utils_Array::value('view', $_REQUEST);


### PR DESCRIPTION
Several civicrm event registrations failed on us with the following error:
Non-static method JApplicationCms::getMenu() should not be called statically
This is a small fix for this issue. (http://issues.civicrm.org/jira/browse/CRM-14226)
