### PR TITLE
CRM-14229 Static call to non static method in Joomla

### DIFF
--- a/site/civicrm.php
+++ b/site/civicrm.php
@@ -58,8 +58,9 @@ function civicrm_invoke() {
   // overrride the GET values if conflict
   if (CRM_Utils_Array::value('Itemid', $_REQUEST)) {
     $component = JComponentHelper::getComponent('com_civicrm');
-    $menu      = JSite::getMenu();
-    $params    = $menu->getParams($_REQUEST['Itemid']);
+    $app       = JFactory::getApplication();
+    $menu      = $app->getMenu();
+    $params    = $menu->getParams($app->input->get('Itemid'));
     $args      = array('task', 'id', 'gid', 'pageId', 'action', 'csid', 'component');
     $view      = CRM_Utils_Array::value('view', $_REQUEST);
     if ($view) {


### PR DESCRIPTION
An old static call to JMenu  in civicrm.php throws a warning in current versions of PHP. This replaces it with the correct code from the Joomla API.
