### PR TITLE
Additional changes for CRM-15846

### DIFF
--- a/site/elements/civicustomsearch.php
+++ b/site/elements/civicustomsearch.php
@@ -52,10 +52,10 @@ class JFormFieldCivicustomsearch extends JFormField {
     require_once 'CRM/Core/Config.php';
     $config = CRM_Core_Config::singleton();
     $query = "
-SELECT value, description
-FROM civicrm_option_value
-WHERE option_group_id =24
-";
+SELECT op_val.value, op_val.description
+FROM civicrm_option_value op_val
+INNER JOIN civicrm_option_group op_group ON (op_group.id = op_val.option_group_id)
+AND op_group.name = 'custom_search'";
     $dao = CRM_Core_DAO::executeQuery($query);
     while ($dao->fetch()) {
       $options[] = JHTML::_('select.option', $dao->value, $dao->description);


### PR DESCRIPTION
https://issues.civicrm.org/jira/browse/CRM-15846

Additional changes for CRM-15846:
In drop down for menu item option, it was showing wrong values instead of custom search values because of wrong option_group_id used in Query.

Changed the query to populate correct values in drop down for custom search. 