### PR TITLE
fix usage for when  $_SESSION only has one member

### DIFF
--- a/site/civicrm.php
+++ b/site/civicrm.php
@@ -48,7 +48,7 @@ function civicrm_invoke() {
     // the session should not be empty
     // however for standalone forms, it will not have any CiviCRM variables in the
     // session either, so dont check for it
-    if (count($_SESSION) <= 1) {
+    if (empty($_SESSION)) {
       $config = CRM_Core_Config::singleton();
       CRM_Utils_System::redirect($config->userFrameworkBaseURL);
     }


### PR DESCRIPTION
$_SESSION only has one member by default in Joomla I believe (__default). The rest of the data is in sub arrays.

Attempting to use https://github.com/teamsinger/uk.teamsinger.civicrm.mailgun to inteface with MailGun's web hooks. When MailGun posts back to CiviCRM, there is only count($_SESSION) equals 1, which kills the script.