### PR TITLE
CRM-15656 Time zone fix in Joomla

### DIFF
--- a/admin/admin.civicrm.php
+++ b/admin/admin.civicrm.php
@@ -64,6 +64,8 @@ function civicrm_initialize() {
 
   require_once 'PEAR.php';
   $config = CRM_Core_Config::singleton();
+  // Set the time zone
+  CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
 }
 
 function plugin_init() {

--- a/site/civicrm.php
+++ b/site/civicrm.php
@@ -36,6 +36,9 @@ function civicrm_initialize() {
   require_once 'PEAR.php';
   $config = CRM_Core_Config::singleton();
 
+   // Set the time zone
+  CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
+
   // this is the front end, so let others know
   $config->userFrameworkFrontend = 1;
 }


### PR DESCRIPTION
This PR fixes the time zone in the Site (Front End) in CiviCRM running Joomla.

---

 * [CRM-15656: Synchronize PHP and MySQL time zones](https://issues.civicrm.org/jira/browse/CRM-15656)