### PR TITLE
CRM-17789 - DB_DSN_MODE for Joomla installer

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -159,6 +159,10 @@ CRM_Core_ClassLoader::singleton()->register();
 
 function civicrm_source($fileName, $lineMode = FALSE) {
 
+  if (!defined('DB_DSN_MODE')) {
+    define('DB_DSN_MODE', 'auto');
+  }
+
   $dsn = CIVICRM_DSN;
 
   require_once 'DB.php';


### PR DESCRIPTION
The Joomla installer should use the same mysqli/mysql toggle as core.

---

 * [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)