### PR TITLE
(dev/drupal#79) Update PHP version checks

### DIFF
--- a/admin/admin.civicrm.php
+++ b/admin/admin.civicrm.php
@@ -53,9 +53,9 @@ function civicrm_init() {
  */
 function civicrm_initialize() {
   // Check for php version and ensure its greater than minPhpVersion
-  $minPhpVersion = '5.3.4';
+  $minPhpVersion = '7.0.0';
   if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
-    echo "CiviCRM requires PHP Version $minPhpVersion or greater. You are running PHP Version " . PHP_VERSION . "<p>";
+    echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
     exit();
   }
 

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -30,6 +30,13 @@ defined('_JEXEC') or die('No direct access allowed');
 global $civicrmUpgrade;
 $civicrmUpgrade = FALSE;
 function civicrm_setup() {
+  // Check for php version and ensure its greater than minPhpVersion
+  $minPhpVersion = '7.0.0';
+  if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
+    echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
+    exit();
+  }
+
   global $adminPath, $compileDir;
 
   $adminPath = JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR . 'com_civicrm';

--- a/site/civicrm.php
+++ b/site/civicrm.php
@@ -24,9 +24,9 @@ function civicrm_init() {
  */
 function civicrm_initialize() {
   // Check for php version and ensure its greater than minPhpVersion
-  $minPhpVersion = '5.3.4';
+  $minPhpVersion = '7.0.0';
   if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
-    echo "CiviCRM requires PHP Version $minPhpVersion or greater. You are running PHP Version " . PHP_VERSION . "<p>";
+    echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
     exit();
   }
 


### PR DESCRIPTION
Overview
--------

If you install or upgrade CiviCRM 5.16+ on PHP 5.x, then it produces a syntax error:

```
Error: syntax error, unexpected ':', expecting '{'
in <...>/civicrm/vendor/league/csv/src/functions.php, line 33
```

It is correct to raise an error, but the error should be more digestable -- i.e. telling the user that their version of PHP is in compatible.

See also: https://lab.civicrm.org/dev/drupal/issues/79

Comments
--------

This patch has two parts:

* Pro-forma changes to existing PHP version checks (s/5.3.4/7.0.0/)
* An additional check which addresses some scenario (installer?) which was still had the ugly error

I started working on this patch after doing a dozen similar PRs for the different repos+branches, and I finally conked out in civicrm-joomla after the 4th iteration of re-running distmaker.  I'm pretty sure this is better than before, but I ran out patience and suspect there are still some scenarios producing the uglier message.

(It should be possible to target a different branch by editing the PR header -- but for the moment, I targetted `master` because I'm not sure when this'll be reviewed.)
