### PR TITLE
(dev/joomla#14) Joomla 4.0 compatibility fixes

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -53,7 +53,8 @@ function civicrm_setup() {
     }
 
     $extractdir = $adminPath;
-    JArchive::extract($archivename, $extractdir);
+    $archive = new Joomla\Archive\Archive;
+    $archive->extract($archivename, $extractdir);
   }
 
   $scratchDir = JPATH_SITE . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'civicrm';
@@ -173,7 +174,7 @@ function civicrm_source($fileName, $lineMode = FALSE) {
   }
 
   if (!$lineMode) {
-    $string = JFile::read($fileName);
+    $string = file_get_contents($fileName);
 
     //get rid of comments starting with # and --
     $string = preg_replace("/^#[^\n]*$/m", "\n", $string);
@@ -233,7 +234,7 @@ function civicrm_config($frontend = FALSE, $siteKey) {
     $params['baseURL'] = $liveSite . '/';
   }
 
-  $str = JFile::read($adminPath . DIRECTORY_SEPARATOR .
+  $str = file_get_contents($adminPath . DIRECTORY_SEPARATOR .
     'civicrm' . DIRECTORY_SEPARATOR .
     'templates' . DIRECTORY_SEPARATOR .
     'CRM' . DIRECTORY_SEPARATOR .

--- a/admin/plugins/civicrm/civicrm.php
+++ b/admin/plugins/civicrm/civicrm.php
@@ -85,8 +85,7 @@ class plgUserCivicrm extends JPlugin {
    * @since    1.6
    */
   public function onUserLogin($user, $options = array()) {
-    $app  = JFactory::getApplication();
-    if ($app->isAdmin()) {
+    if (self::isAdminBackend()) {
       $jUser = JFactory::getUser();
       $jId = $jUser->get('id');
       self::civicrmResetNavigation($jId);
@@ -123,6 +122,29 @@ class plgUserCivicrm extends JPlugin {
 
     // Reset Navigation
     CRM_Core_BAO_Navigation::resetNavigation($cId);
+  }
+
+  /**
+   * Determine if we are in the Joomla administrator backend
+   *
+   * @return boolean True if in the Joomla Administrator backend otherwise false
+   */
+  private function isAdminBackend() {
+    $app = JFactory::getApplication();
+
+    // Determine if we are in the Joomla administrator backend
+    // In Joomla 3.7+ the isClient() method is used. In earlier versions use the isAdmin() method (deprecated in Joomla 4.0).
+    if (method_exists($app, 'isClient')) {
+      $isAdmin = $app->isClient('administrator');
+    }
+    elseif (method_exists($app, 'isAdmin')) {
+      $isAdmin = $app->isAdmin();
+    }
+    else {
+      throw new \Exception("CiviCRM User Plugin error: no method found to determine Joomla client interface.");
+    }
+
+    return $isAdmin;
   }
 
 }

--- a/script.civicrm.php
+++ b/script.civicrm.php
@@ -83,8 +83,21 @@ class Com_CiviCRMInstallerScript {
   </center>';
     }
 
-    //install and enable plugins
-    $manifest  = $parent->get("manifest");
+    // Install and enable plugins
+
+    // Get the installer manifest. Use the getManifest() method if it exists (Joomla 3.4+)
+    // If not then use get("manifest") (deprecated in Joomla 4.0).
+    if (method_exists($parent, 'getManifest')) {
+      $manifest = $parent->getManifest();
+    }
+    elseif (method_exists($parent, 'get')) {
+      $manifest = $parent->get("manifest");
+    }
+    else {
+      echo "No method found to get Joomla installer manifest.";
+      exit();
+    }
+
     $parent    = $parent->getParent();
     $source    = $parent->getPath("source");
     $installer = new JInstaller();
@@ -130,7 +143,7 @@ SET    $columnEnabled = 1
 WHERE  $columnElement IN ($plgList)
 AND    $columnType = 'plugin'
 ");
-    $db->query();
+    $db->execute();
 
     echo $content;
   }
@@ -268,7 +281,7 @@ AND    $columnType = 'plugin'
       ' WHERE name = ' .
       $db->quote('com_civicrm')
     );
-    if (!$db->query()) {
+    if (!$db->execute()) {
       echo 'Seems like setting default actions failed<p>';
     }
   }


### PR DESCRIPTION
## Overview
This PR aims to do the minimum to get CiviCRM into a state where it can be successfully installed on Joomla 4.0.

## Before
The CiviCRM installer fails on Joomla 4.0 due to multiple methods that have been deprecated.

## After
The CiviCRM installer works on Joomla 4.0

## Technical Details
#### `configure.php`:
Problem 1: `JArchive::Extract()` is deprecated
Solution 1: Use the `extract()` method of Joomla\Archive\Archive instead (available since Joomla 1.0)

Ref: https://api.joomla.org/cms-3/classes/Joomla.Archive.Archive.html#method_extract

Problem 2: `JFile::read()` is deprecated. Two instances of this.
Solution 2: Use PHP's native `file_get_contents()` instead

Ref: https://api.joomla.org/cms-3/classes/JFile.html#method_read - advice is "Use the native file_get_contents() instead."

#### `script.civicrm.php`:
Problem 3: `get("manifest")` is deprecated in Joomla 4.0
Solution 3: Use `getManifest()` instead. This method only exists from Joomla 3.4 so we need to use whichever of the two methods exist.

Ref: https://api.joomla.org/cms-3/classes/Joomla.CMS.Installer.Adapter.PackageAdapter.html#method_getManifest

Problem 4: `query()` method of `JDatabaseDriver` is deprecated in Joomla 4.0. Two instances of this.
Solution 4: Use `execute()` instead. This method exists in Joomla 3.0+ so we can just do a straight replacement.

Ref: https://api.joomla.org/cms-3/classes/JDatabaseDriver.html#method_query
https://api.joomla.org/cms-3/classes/JDatabaseDriver.html#method_execute

#### `admin/plugins/civicrm/civicrm.php` (CiviCRM User Management plugin)
This is only evident after CiviCRM has been installed but is a showstopper because it's not possible to log in to the Joomla Administrator backend - nothing happens, whereas the other fixes above are all required for the installer.

Problem 5: The `JFactory::getApplication()->isAdmin()` method is deprecated in Joomla 4.0.
Solution 5: Use `JFactory::getApplication()->isClient('administrator')` instead, but this only exists on Joomla 3.7+ so need to use whichever method is available.

## Comments
We only support Joomla 3.0+ now, as per https://docs.civicrm.org/sysadmin/en/latest/requirements/
Note that this PR will break the CiviCRM installer on earlier Joomla versions (2.5.x and earlier) due to the use of `JDatabaseDiver::execute()`. If people think that's undesirable we could add extra code to use whichever of `execute()` and `query()` is available.

Useful document here: https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4

There are some styling issues and the new CiviCRM menu doesn't get positioned nicely with Joomla 4.0 but those issues are out of scope for this PR.