### PR TITLE
(dev/Joomla#15) Fix PHP 7.2 warning after installation

### DIFF
--- a/script.civicrm.php
+++ b/script.civicrm.php
@@ -177,10 +177,9 @@ AND    $columnType = 'plugin'
     // only set if its empty
     $db = JFactory::getDbo();
     $db->setQuery('SELECT rules FROM #__assets WHERE name = ' . $db->quote('com_civicrm'));
-    $assetRules = json_decode((string ) $db->loadResult());
+    $assetRules = json_decode((string) $db->loadResult(), TRUE);
 
-
-    if (count($assetRules) > 1) {
+    if (is_array($assetRules) && count($assetRules) > 1) {
       return;
     }
 


### PR DESCRIPTION
## Overview
This PR fixes a PHP 7.2 warning, which appears after the installer has finished. See https://lab.civicrm.org/dev/joomla/issues/15

I found this while doing some Joomla 4.0 testing but it applies to previous versions too.

## Before
After the installer has finished, this warning is displayed:
`Warning: count(): Parameter must be an array or an object that implements Countable in /var/www/html/j4/tmp/install_5d60cbd7ce50c/com_civicrm/script.civicrm.php on line 196`

## After
No warning

## Technical details
I have added the second parameter to the `json_decode` so that it returns an array.

Also use `is_array` before `count` to ensure that `$assetRules` is not null.

## Comments