### PR TITLE
Check if valid UF Match exists in user plugin

### DIFF
--- a/admin/plugins/civicrm/civicrm.php
+++ b/admin/plugins/civicrm/civicrm.php
@@ -118,7 +118,10 @@ class plgUserCivicrm extends JPlugin {
         'uf_id' => $jId,
         'return' => 'contact_id',
       );
-      $cId = civicrm_api('uf_match', 'getvalue', $params);
+      $result = civicrm_api('uf_match', 'getvalue', $params);
+      // If no match is found, will return an error array
+      if (is_int($result))
+        $cId = $result;
     }
 
     // Reset Navigation


### PR DESCRIPTION
Plugins that hijack authentication suck as Akeeba Login Guard (https://www.akeebabackup.com/products/loginguard.html) can cause no UF Match to be made on new users. This causes an error when resetting navigation.