### PR TITLE
CiviCRM-Joomla should accept web-service calls

### DIFF
--- a/site/civicrm.php
+++ b/site/civicrm.php
@@ -48,18 +48,6 @@ function civicrm_initialize() {
 function civicrm_invoke() {
   civicrm_initialize();
 
-  // check and ensure that we have a valid session
-  if (!empty($_POST)) {
-    $urlStart = substr(stripslashes(CRM_Utils_Array::value('task', $_GET)), 0, 19);
-    // the session should not be empty
-    // however for standalone forms, it will not have any CiviCRM variables in the
-    // session either, so dont check for it
-    if (empty($_SESSION) && $urlStart != 'civicrm/payment/ipn') {
-      $config = CRM_Core_Config::singleton();
-      CRM_Utils_System::redirect($config->userFrameworkBaseURL);
-    }
-  }
-
   // add all the values from the itemId param
   // overrride the GET values if conflict
   if (!empty($_REQUEST['Itemid'])) {


### PR DESCRIPTION
Overview
--------

In a stock configuration of CiviCRM-Joomla, it is not possible to create a page-route for accepting web-service calls.  This is a common need for extensions.

Suppose, for example, an extension defines a route `civicrm/my-web-hook`. The intent is that some external party (*perhaps `curl`*) will POST data here. How does that request play out?

Before
------

If any external party POSTs to `civicrm/my-web-hook`, the page won't actually be processed. This takes a moment to see, though, because Joomla is blessed with multiple ways to construct requests -- and each has its own issue.

```bash
## Backend URL
curl -X POST 'http://example.org/administrator/?option=com_civicrm&task=civicrm/my-web-hook'

## Frontend URL
curl -X POST 'http://example.org/index.php?option=com_civicrm&task=civicrm/my-web-hook'
```

The backend URL fails because Joomla (upstream) has a general policy -- if anyone requests `/administrator/` without an active session, then they are redirected to the login form.  The redirect kicks in before we get a chance to process the web-hook. (*I haven't dug deep enough to see if this is configurable... but it's empirically the stock behavior...*)

The frontend URL fails because `civicrm-joomla` has a hard-coded policy -- if anyone POSTs to any Civi page without an active session, then they are redirected to the home page.  The redirect again prevents us from receiving the web-hook.  This policy was introduced by:

* https://github.com/civicrm/civicrm-svn/commit/bd8b79f35c2c4c45f3bfd74405fcdeb0900055b2
* https://issues.civicrm.org/jira/browse/CRM-4073

Interestingly, we have been bitten by this problem before, as in:

https://issues.civicrm.org/jira/browse/CRM-18483

However, that used a narrow fix which only allows `civicrm/payment/ipn` -- it doesn't allow any others.

After
-----

The frontend URL for `civicrm/my-web-hook` will accept POSTs.

Comments
--------

This changes the part that is under our control (ie the frontend policy).

There is some merit in the original idea of CRM-4073 -- but if one cares about that scenario, it should be done differently, ie

* It should communicate to the user what happened -- tell them that their session expired and that they need to retry. (If you have an old tab open, click "Submit", and quietly redirect to the home page...  then you may assume that the request succeeded!)
* The session-expired situation is not unique to Joomla frontend. You can get the same problem in the frontend of any CMS, and you can get the same problem in other backends.
* The policy should not be hard-coded to only accept POSTs for a single core route.  It should be possible for any part (core/extension/contrib) to register a mix of routes which do -- or do not -- get the protection.