### PR TITLE
Fix generating civicrm.settings.php by ensuring that CMSdbSSL and dbS…

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -242,6 +242,8 @@ function civicrm_config($frontend = FALSE, $siteKey, $credKeys, $signKeys) {
     'siteKey' => $siteKey,
     'credKeys' => $credKeys,
     'signKeys' => $signKeys,
+    'dbSSL' => '',
+    'CMSdbSSL' => '',
   );
 
   if ($frontend) {


### PR DESCRIPTION
…SL variables are properly removed from the DSNs

Doing a recent upgrade of a Joomla site I found that the `%%CMSdbSSL%%` and `%%dbSSL%%` was still printed at the end of the DSNs

This should remove it and there doesn't seem to be a way to determine if we are using ssl in Joomla but this should be a reasonable intermediate step

ping @lcdservices @totten @demeritcowboy 