### PR TITLE
dev/joomla#16 : [Joomla 4.0] CiviCRM logo not showing in Quick Icon plugin

### DIFF
--- a/admin/plugins/civicrmicon/civicrmicon.php
+++ b/admin/plugins/civicrmicon/civicrmicon.php
@@ -38,6 +38,11 @@ class plgQuickiconCivicrmicon extends JPlugin {
    * @since       2.5
    */
   public function onGetIcons($context) {
+    // exclude CiviCRM quick icons from notification and system block
+    if ($context == 'system_quickicon' || $context == 'update_quickicon') {
+      return [];
+    }
+
     jimport('joomla.environment.uri');
     $icon = array(
       array(
@@ -45,20 +50,26 @@ class plgQuickiconCivicrmicon extends JPlugin {
         'image' => JURI::base() . 'components/com_civicrm/civicrm/i/smallLogo.png',
         'text' => 'CiviCRM',
         'id' => 'plg_quickicon_civicrmicon',
+        'class' => $context == 'mod_quickicon' ? 'success' : '',
       ),
     );
 
     //image must be handled via css class in J3.0
     if (version_compare(JVERSION, '3.0', 'ge')) {
-      $img = JURI::root() . 'plugins/quickicon/civicrmicon/smallLogo14.png';
-      $css = '
+      $img = version_compare(JVERSION, '4.0', 'ge') ? $icon[0]['image'] : JURI::root() . 'plugins/quickicon/civicrmicon/smallLogo14.png';
+      $additonalAttributes = version_compare(JVERSION, '4.0', 'ge') ? 'height:50px;width:50px;' : '';
+      $css = "
         .icon-civicrm, .icon-civicrm-open {
-          background-image:url("' . $img . '");
+          {$additonalAttributes}
+          background-image:url(\"{$img}\");
         }
-      ';
+      ";
       $document = JFactory::getDocument();
       $document->addStyleDeclaration($css);
       $icon[0]['image'] = 'civicrm';
+      if (version_compare(JVERSION, '4.0', 'ge')) {
+        $icon[0]['image'] = 'icon-civicrm';
+      }
     }
     else {
       $icon[0]['image'] = JURI::base() . 'components/com_civicrm/civicrm/i/smallLogo.png';


### PR DESCRIPTION
BEFORE
--------
![before](https://user-images.githubusercontent.com/3735621/170027398-28cf62bc-e2cd-4103-9b46-f1eabe193420.gif)


AFTER
-------
![before1](https://user-images.githubusercontent.com/3735621/170027456-b8810186-ea50-4932-8d91-07ae996918c9.gif)


In addition, I have excluded the CiviCRM icon from the Notification and System block. 