### PR TITLE
dev/core#3991 Bump minimum PHP version to 7.3.0

### DIFF
--- a/admin/admin.civicrm.php
+++ b/admin/admin.civicrm.php
@@ -53,7 +53,7 @@ function civicrm_init() {
  */
 function civicrm_initialize() {
   // Check for php version and ensure its greater than minPhpVersion
-  $minPhpVersion = '7.0.0';
+  $minPhpVersion = '7.3.0';
   if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
     echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
     exit();

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -31,7 +31,7 @@ global $civicrmUpgrade;
 $civicrmUpgrade = FALSE;
 function civicrm_setup() {
   // Check for php version and ensure its greater than minPhpVersion
-  $minPhpVersion = '7.0.0';
+  $minPhpVersion = '7.3.0';
   if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
     echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
     exit();

--- a/site/civicrm.php
+++ b/site/civicrm.php
@@ -24,7 +24,7 @@ function civicrm_init() {
  */
 function civicrm_initialize() {
   // Check for php version and ensure its greater than minPhpVersion
-  $minPhpVersion = '7.0.0';
+  $minPhpVersion = '7.3.0';
   if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
     echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
     exit();


### PR DESCRIPTION
This bumps the minimum install PHP version from 7.0 to 7.3 as per the ticket

ping @colemanw @totten @eileenmcnaughton 