### PR TITLE
(dev/core#1615) Use Setup API for installation

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -45,25 +45,7 @@ function civicrm_setup() {
   $jConfig = new JConfig();
   set_time_limit(4000);
 
-  // Path to the archive
-  $archivename = $adminPath . DIRECTORY_SEPARATOR . 'civicrm.zip';
-
-  // a bit of support for the non-alternaive joomla install
-  if (file_exists($archivename)) {
-    // ensure that the site has native zip, else abort
-    if (
-      !function_exists('zip_open') ||
-      !function_exists('zip_read')
-    ) {
-      echo "Your PHP version is missing  zip functionality. Please ask your system administrator / hosting provider to recompile PHP with zip support.<p>";
-      echo "If this is a new install, you will need to uninstall CiviCRM from the Joomla Extension Manager.<p>";
-      exit();
-    }
-
-    $extractdir = $adminPath;
-    $archive = new Joomla\Archive\Archive();
-    $archive->extract($archivename, $extractdir);
-  }
+  civicrm_extract_code($adminPath);
 
   $scratchDir = JPATH_SITE . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'civicrm';
   if (!is_dir($scratchDir)) {
@@ -83,6 +65,33 @@ AND table_schema = "' . $jConfig->db . '" ');
 
   global $civicrmUpgrade;
   $civicrmUpgrade = ($db->loadResult() == 0) ? FALSE : TRUE;
+}
+
+/**
+ * If present, convert "admin/civicrm.zip" to "admin/civicrm/".
+ *
+ * @param string $adminPath
+ * @return void
+ */
+function civicrm_extract_code(string $adminPath) {
+  $archivename = $adminPath . DIRECTORY_SEPARATOR . 'civicrm.zip';
+
+  // a bit of support for the non-alternaive joomla install
+  if (file_exists($archivename)) {
+    // ensure that the site has native zip, else abort
+    if (
+      !function_exists('zip_open') ||
+      !function_exists('zip_read')
+    ) {
+      echo "Your PHP version is missing  zip functionality. Please ask your system administrator / hosting provider to recompile PHP with zip support.<p>";
+      echo "If this is a new install, you will need to uninstall CiviCRM from the Joomla Extension Manager.<p>";
+      exit();
+    }
+
+    $extractdir = $adminPath;
+    $archive = new Joomla\Archive\Archive();
+    $archive->extract($archivename, $extractdir);
+  }
 }
 
 function civicrm_write_file($name, &$buffer) {

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -30,34 +30,6 @@ defined('_JEXEC') or die('No direct access allowed');
 global $civicrmUpgrade;
 $civicrmUpgrade = FALSE;
 
-function civicrm_setup() {
-  // Check for php version and ensure its greater than minPhpVersion
-  $minPhpVersion = '7.3.0';
-  if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
-    echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
-    exit();
-  }
-
-  global $adminPath, $compileDir;
-
-  $adminPath = JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR . 'com_civicrm';
-
-  civicrm_extract_code($adminPath);
-
-  $scratchDir = JPATH_SITE . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'civicrm';
-  if (!is_dir($scratchDir)) {
-    JFolder::create($scratchDir, 0777);
-  }
-
-  $compileDir = $scratchDir . DIRECTORY_SEPARATOR . 'templates_c';
-  if (!is_dir($compileDir)) {
-    JFolder::create($compileDir, 0777);
-  }
-
-  global $civicrmUpgrade;
-  $civicrmUpgrade = civicrm_detect_upgrade();
-}
-
 /**
  * If present, convert "admin/civicrm.zip" to "admin/civicrm/".
  *
@@ -90,9 +62,30 @@ function civicrm_write_file($name, &$buffer) {
 }
 
 function civicrm_main() {
-  global $civicrmUpgrade, $adminPath;
+  global $civicrmUpgrade, $adminPath, $compileDir;
 
-  civicrm_setup();
+  // Check for php version and ensure its greater than minPhpVersion
+  $minPhpVersion = '7.3.0';
+  if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
+    echo "CiviCRM requires PHP version $minPhpVersion or greater. You are running PHP version " . PHP_VERSION . "<p>";
+    exit();
+  }
+
+  $adminPath = JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR . 'com_civicrm';
+
+  civicrm_extract_code($adminPath);
+
+  $scratchDir = JPATH_SITE . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'civicrm';
+  if (!is_dir($scratchDir)) {
+    JFolder::create($scratchDir, 0777);
+  }
+
+  $compileDir = $scratchDir . DIRECTORY_SEPARATOR . 'templates_c';
+  if (!is_dir($compileDir)) {
+    JFolder::create($compileDir, 0777);
+  }
+
+  $civicrmUpgrade = civicrm_detect_upgrade();
 
   // setup vars
   $configFile = $adminPath . DIRECTORY_SEPARATOR . 'civicrm.settings.php';

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -42,8 +42,6 @@ function civicrm_setup() {
 
   $adminPath = JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR . 'com_civicrm';
 
-  $jConfig = new JConfig();
-
   civicrm_extract_code($adminPath);
 
   $scratchDir = JPATH_SITE . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'civicrm';
@@ -56,14 +54,8 @@ function civicrm_setup() {
     JFolder::create($compileDir, 0777);
   }
 
-  $db = JFactory::getDBO();
-  $db->setQuery(' SELECT count( * )
-FROM information_schema.tables
-WHERE table_name LIKE "civicrm_domain"
-AND table_schema = "' . $jConfig->db . '" ');
-
   global $civicrmUpgrade;
-  $civicrmUpgrade = ($db->loadResult() == 0) ? FALSE : TRUE;
+  $civicrmUpgrade = civicrm_detect_upgrade();
 }
 
 /**
@@ -290,6 +282,22 @@ function civicrm_config($frontend = FALSE, $siteKey, $credKeys, $signKeys) {
     $str = str_replace('%%' . $key . '%%', $value, $str);
   }
   return trim($str);
+}
+
+/**
+ * @return bool
+ *   TRUE if this installation operation is actually an upgrade.
+ */
+function civicrm_detect_upgrade(): bool {
+  $jConfig = new JConfig();
+  $db = JFactory::getDBO();
+  $db->setQuery(' SELECT count( * )
+FROM information_schema.tables
+WHERE table_name LIKE "civicrm_domain"
+AND table_schema = "' . $jConfig->db . '" ');
+
+  $civicrmUpgrade = ($db->loadResult() == 0) ? FALSE : TRUE;
+  return $civicrmUpgrade;
 }
 
 set_time_limit(4000); /* Ex: ZIP extraction */

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -57,10 +57,6 @@ function civicrm_extract_code(string $adminPath) {
   }
 }
 
-function civicrm_write_file($name, &$buffer) {
-  JFile::write($name, $buffer);
-}
-
 function civicrm_main() {
   global $civicrmUpgrade, $adminPath;
 
@@ -108,7 +104,7 @@ CRM_Core_ClassLoader::singleton()->register();
 ";
 
   $string = trim($string);
-  civicrm_write_file($adminPath . DIRECTORY_SEPARATOR .
+  JFile::write($adminPath . DIRECTORY_SEPARATOR .
     'civicrm' . DIRECTORY_SEPARATOR .
     'civicrm.config.php',
     $string

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -29,6 +29,7 @@ defined('_JEXEC') or die('No direct access allowed');
 
 global $civicrmUpgrade;
 $civicrmUpgrade = FALSE;
+
 function civicrm_setup() {
   // Check for php version and ensure its greater than minPhpVersion
   $minPhpVersion = '7.3.0';
@@ -60,7 +61,7 @@ function civicrm_setup() {
     }
 
     $extractdir = $adminPath;
-    $archive = new Joomla\Archive\Archive;
+    $archive = new Joomla\Archive\Archive();
     $archive->extract($archivename, $extractdir);
   }
 

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -107,26 +107,7 @@ function civicrm_main() {
   $configFile = $adminPath . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
 
   // generate backend config file
-  $string = "
-<?php
-define('CIVICRM_SETTINGS_PATH', '$configFile');
-\$error = @include_once( '$configFile' );
-if ( \$error == false ) {
-    echo \"Could not load the settings file at: {$configFile}\n\";
-    exit( );
-}
-
-// Load class loader
-require_once \$civicrm_root . '/CRM/Core/ClassLoader.php';
-CRM_Core_ClassLoader::singleton()->register();
-";
-
-  $string = trim($string);
-  civicrm_write_file($adminPath . DIRECTORY_SEPARATOR .
-    'civicrm' . DIRECTORY_SEPARATOR .
-    'civicrm.config.php',
-    $string
-  );
+  civicrm_backend_config($configFile, $adminPath);
 
   $liveSite = substr_replace(JURI::root(), '', -1, 1);
   if ($civicrmUpgrade) {
@@ -185,6 +166,38 @@ CRM_Core_ClassLoader::singleton()->register();
     require_once 'CRM/Core/Menu.php';
     CRM_Core_Menu::store();
   }
+}
+
+/**
+ * Generate a "civicrm.config.php" file in the civicrm app-root.
+ * This (probably) allows backend tools like "extern/rest.php" or "bin/cli.php".
+ *
+ * @param string $configFile
+ * @param $adminPath
+ * @return string
+ */
+function civicrm_backend_config(string $configFile, $adminPath): string {
+  $string = "
+<?php
+define('CIVICRM_SETTINGS_PATH', '$configFile');
+\$error = @include_once( '$configFile' );
+if ( \$error == false ) {
+    echo \"Could not load the settings file at: {$configFile}\n\";
+    exit( );
+}
+
+// Load class loader
+require_once \$civicrm_root . '/CRM/Core/ClassLoader.php';
+CRM_Core_ClassLoader::singleton()->register();
+";
+
+  $string = trim($string);
+  civicrm_write_file($adminPath . DIRECTORY_SEPARATOR .
+    'civicrm' . DIRECTORY_SEPARATOR .
+    'civicrm.config.php',
+    $string
+  );
+  return $string;
 }
 
 function civicrm_source($fileName, $lineMode = FALSE) {

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -43,7 +43,6 @@ function civicrm_setup() {
   $adminPath = JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR . 'com_civicrm';
 
   $jConfig = new JConfig();
-  set_time_limit(4000);
 
   civicrm_extract_code($adminPath);
 
@@ -293,4 +292,5 @@ function civicrm_config($frontend = FALSE, $siteKey, $credKeys, $signKeys) {
   return trim($str);
 }
 
+set_time_limit(4000); /* Ex: ZIP extraction */
 civicrm_main();


### PR DESCRIPTION
Overview
------------

As discussed in https://lab.civicrm.org/dev/core/-/issues/1615, we need to switch various installers (such as Joomla's installer) over to the "Civi\Setup" API. This ensures that full-weight extensions (like SearchKit) can be auto-installed on new deployments.

Before
--------

`civicrm-joomla` uses its own installation sequence.

After
------

`civicrm-joomla` uses `Civi\Setup` API to create the `civicrm.settings.php` and to install the schema.

Comments
---------------

* https://github.com/civicrm/civicrm-core/pull/26677 is suggested before tackling this - as it allows faster rebuilds.
* https://github.com/civicrm/civicrm-core/pull/26678 is required first - as it enables some behaviors needed for Joomla installation.
* I've done some initial testing on a clean site running Joomla 4.3.2. __This also needs close testing on the upgrade-experience__ -- i.e. to ensure that (a) upgrades generally work and (b) data from `civicrm.settings.php` is properly preserved (esp site-key, signing keys, credential keys).
* I used `$setup->installFiles()` and `$setup->installDatabase()`. I'm not sure about whether to incorporate `$setup->checkRequirements()` -- that would perform more thorough requirements-checking. However, there are a lot of checks which we have never enforced on Joomla before. This probably needs some experimentation/thinking about the effect on page-flow/error-handling. However, the current approach should achieve parity with the existing installer - and I think it's fair to defer `$setup->checkRequirements()` to a future PR.