### PR TITLE
Use the deleted file list to remove old files after installation

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -55,6 +55,14 @@ function civicrm_extract_code(string $adminPath) {
     $archive = new Joomla\Archive\Archive();
     $archive->extract($archivename, $extractdir);
   }
+
+  $deletedFilesList = json_decode(file_get_contents($adminPath . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'deleted-files-list.json'));
+  foreach ($deletedFilesList as $deletedFile) {
+    $filePath = $adminPath . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . $deletedFile;
+    if (file_exists($filePath)) {
+      unlink($filePath);
+    }
+  }
 }
 
 function civicrm_main() {


### PR DESCRIPTION
## Overview
Using the deleted files list from https://github.com/civicrm/civicrm-core/pull/28653, the Joomla installers will now remove files from the filesystem that don't exist in the version being installed.

## Before
The default Joomla installation process doesn't delete files on upgrade. This leads to outdated files that at best don't do anything and at worst can cause fatal errors.

## After
The Joomla installation process now deletes files based on the deleted-files-list.json