### PR TITLE
Fix event listing as front page for Joomla 4

### DIFF
--- a/site/views/Events/tmpl/eventlisting.xml
+++ b/site/views/Events/tmpl/eventlisting.xml
@@ -25,7 +25,7 @@
           />
         <field name="task"
                type="hidden"
-               default="civicrm/event/ical"
+               default="civicrm/event/list"
                required="true"
           />
         <field name="reset"


### PR DESCRIPTION
A Joomla 3 site with the event listing as the front page, did not work when updated to J4, front page was empty.

After much headscratching I found that the menu items was created with `task=civicrm/event/ical`, which seemed suspicious to me. I might be wrong, but debugging indicated that it should be `task=civicrm/event/list`.

I don't know how `task=civicrm/event/ical` could ever work to produce a listing, but in J3 somehow `CRM_Core_Invoke::invoke()` seemed to turn this into a another request with 'list'.

In Joomla 4 this still worked if you had the event listing as a menu item, but not if you made that the default/home/front page. This resulted in Joomla 4 sites that had this as first page turned empty.

During my debugging I modernized the `site/civicrm.php` to handle the arguments a bit more like modern Joomla code (> J3.0) and the XML-update alone did not work.

This PR should work for J3 also. (CiviCRM are not supporting Joomla below v3 I hope...)