### PR TITLE
Use associative array keys for permission attributes

### DIFF
--- a/libraries/joomla/form/fields/civiperms.php
+++ b/libraries/joomla/form/fields/civiperms.php
@@ -304,8 +304,8 @@ class JFormFieldCiviperms extends JFormFieldRules {
       $translation = self::$civiConfig->userPermissionClass->translateJoomlaPermission($key);
       $actions[] = (object) array(
         'name' => $translation[0],
-        'title' => $perm[0],
-        'description' => $perm[1],
+        'title' => $perm['label'],
+        'description' => $perm['description'],
       );
     }
 


### PR DESCRIPTION
### Overview

Fix for https://lab.civicrm.org/dev/joomla/-/issues/56 - refactor JFormFieldCiviperms::getCiviperms() to use associative keys when retrieving the `label` and `description` of CiviCRM extension permissions.

This is necessary for compatibility with CiviCRM 5.71+. Otherwise, the extension permissions have no labels in the Joomla permissions management console!

### Before (errant behaviour)

![Screenshot 2024-04-19 154953](https://github.com/civicrm/civicrm-joomla/assets/72983627/b80b119e-b01f-4aaf-9126-30be3085c426)

### After (expected behaviour)

![Screenshot 2024-04-19 171100](https://github.com/civicrm/civicrm-joomla/assets/72983627/c60ba92b-744a-4f1b-af68-5b61d60118f3)

### Notes

Tested and working on CiviCRM 5.72.1 / Joomla 3.10.