### PR TITLE
(dev/core#5128) Installer/Upgrader misfires in presence of certain passwords

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -185,8 +185,11 @@ function civicrm_detect_upgrade(): bool {
     require_once $configFile;
 
     if (defined("CIVICRM_DSN")) {
-      $civiDSNParts = parse_url(CIVICRM_DSN);
-      $database = substr($civiDSNParts['path'], 1);
+      if (!class_exists('DB')) {
+        require_once 'DB.php';
+      }
+      $civiDSNParts = DB::parseDSN(CIVICRM_DSN);
+      $database = $civiDSNParts['database'];
     }
   }
 


### PR DESCRIPTION
Overview
--------

CiviCRM-Joomla upgrade fails if:

1. The MySQL password includes a URL meta-character (like `#`), and
2. The -prior- version of CiviCRM was 5.66 or older.

Specifically, the failure relates to `civicrm_detect_upgrade()`.  This utility function analyzes your MySQL setup and decides whether to do an installation or upgrade.  If the function misfires, then you wind up executing a new-installation instead of executing the upgrader.

cc @seamuslee001 @aydun @chrisgaraffa

See: https://lab.civicrm.org/dev/core/-/issues/5128

Steps to Reproduce
------------------

* Configure MySQL with a password like `a#a{`. Note that `#` is a URL metacharacter.
* Install Joomla 4.4.3.
* Install CiviCRM 5.66.2. (This writes a `CIVICRM_DSN` with a password containing literal `#`, which is not URL-conformant.)
* Upgrade to CiviCRM 5.73.3.

Before
------

`civicrm_detect_upgrade()` examines the MySQL settings.  It uses `parse_url()` to inspect the old value of `CIVICRM_DSN`.  The `CIVICRM_DSN` includes a literal `#` in the password. `parse_url()` interprets this as a URL "fragment" -- and we ultimately fail to read the database name.

After
-----

`civicrm_detect_upgrade()` examines the MySQL settings.  It uses `DB::parseDSN()` which is more forgiving. (It accepts a password with literal `#`.)

Comments
--------

* In CiviCRM `<=5.66`, the installer-upgrader creates a config file with non-URL-conformant notation.
    ```php
    define('CIVICRM_DSN', 'mysql://j4:a#a{@127.0.0.1:3307/j4?new_link=true')
    ```
* In CiviCRM `>=5.67`, the installer-upgrader creates a config file with URL-conformant notation.
    ```php
    define('CIVICRM_DSN', 'mysql://j4:a%23a%7B@127.0.0.1:3307/j4?new_link=true');
    ```
* In CiviCRM `5.72`, the installer-upgrader starts to use `parse_url()`, which expects URL-conformance. That expectations is met for some (but not all) upgrades.
* I was nervous about whether `DB` class would be loadable at this point. (*It's nice `parse_url()` is in the standard library...*) But... in my hacked-up copy of `civicrm-5.73.3-joomla.zip`, it seems to work...