### PR TITLE
[dev/joomla#60] Use correct DB client to detect upgrade

### DIFF
--- a/admin/configure.php
+++ b/admin/configure.php
@@ -159,8 +159,8 @@ function civicrm_setup_instance(string $adminPath, bool $civicrmUpgrade): \Civi\
   $model->templateCompilePath = implode(DIRECTORY_SEPARATOR, [JPATH_SITE, 'media', 'civicrm', 'templates_c']);
   $model->lang = 'en_US'; /* Joomla installer historically only did `civicrm_data.mysql`. Should fix this... */
 
-  if ($civicrmUpgrade) {
-    require_once $setup->getModel()->settingsPath;
+  if (is_readable($model->settingsPath)) {
+    require_once $model->settingsPath;
     if (defined('CIVICRM_DSN')) {
       $civiDSNParts = DB::parseDSN(CIVICRM_DSN);
       $model->db['username'] = $civiDSNParts['username'];
@@ -172,13 +172,13 @@ function civicrm_setup_instance(string $adminPath, bool $civicrmUpgrade): \Civi\
       $model->db['database'] = $civiDSNParts['database'];
     }
     if (defined('CIVICRM_SITE_KEY')) {
-      $setup->getModel()->siteKey = CIVICRM_SITE_KEY;
+      $model->siteKey = CIVICRM_SITE_KEY;
     }
     if (defined('CIVICRM_CRED_KEYS')) {
-      $setup->getModel()->credKeys = explode(' ', CIVICRM_CRED_KEYS);
+      $model->credKeys = explode(' ', CIVICRM_CRED_KEYS);
     }
     if (defined('CIVICRM_SIGN_KEYS')) {
-      $setup->getModel()->signKeys = explode(' ', CIVICRM_SIGN_KEYS);
+      $model->signKeys = explode(' ', CIVICRM_SIGN_KEYS);
     }
   }
 
@@ -198,7 +198,7 @@ function civicrm_detect_upgrade(): bool {
   if (is_readable($configFile)) {
     require_once $configFile;
 
-    if (defined("CIVICRM_DSN")) {
+    if (defined('CIVICRM_DSN')) {
       if (!class_exists('DB')) {
         require_once 'DB.php';
       }
@@ -207,18 +207,30 @@ function civicrm_detect_upgrade(): bool {
     }
   }
 
-  if (version_compare(JVERSION, '4.0', 'ge')) {
-    $db = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
-  }
-  else {
-    $db = JFactory::getDbo();
-  }
-  $db->setQuery(' SELECT count( * )
+  $sqlCountDomainTables = ' SELECT count( * )
 FROM information_schema.tables
 WHERE table_name LIKE "civicrm_domain"
-AND table_schema = "' . $database . '" ');
+AND table_schema = "' . $database . '" ';
+  $countDomainTables = 0;
 
-  $civicrmUpgrade = ($db->loadResult() == 0) ? FALSE : TRUE;
+  // if the CiviCRM and CMS database credentials are different, connect to the server using the
+  // right ones, to ensure we have access to the $database and can see it in information_schema
+  if ($database != $jConfig->db) {
+    CRM_Core_DAO::init(CIVICRM_DSN);
+    $countDomainTables = CRM_Core_DAO::singleValueQuery($sqlCountDomainTables);
+  }
+  else {
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $db = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+    }
+    else {
+      $db = JFactory::getDbo();
+    }
+    $db->setQuery($sqlCountDomainTables);
+    $countDomainTables = $db->loadResult();
+  }
+
+  $civicrmUpgrade = ($countDomainTables == 0) ? FALSE : TRUE;
   return $civicrmUpgrade;
 }
 

--- a/admin/configure.php
+++ b/admin/configure.php
@@ -70,9 +70,9 @@ function civicrm_main() {
   $adminPath = JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR . 'com_civicrm';
   civicrm_extract_code($adminPath);
 
-  $civicrmUpgrade = civicrm_detect_upgrade();
+  $setup = civicrm_setup_instance($adminPath);
 
-  $setup = civicrm_setup_instance($adminPath, $civicrmUpgrade);
+  $civicrmUpgrade = civicrm_detect_upgrade($setup);
 
   civicrm_backend_config($setup->getModel()->settingsPath, $adminPath);
   $setup->installFiles();
@@ -127,7 +127,7 @@ CRM_Core_ClassLoader::singleton()->register();
  * @return \Civi\Setup
  * @throws \Exception
  */
-function civicrm_setup_instance(string $adminPath, bool $civicrmUpgrade): \Civi\Setup {
+function civicrm_setup_instance(string $adminPath): \Civi\Setup {
   $civicrmCore = $adminPath . DIRECTORY_SEPARATOR . 'civicrm';
 
   require_once implode(DIRECTORY_SEPARATOR, [$civicrmCore, 'CRM', 'Core', 'ClassLoader.php']);
@@ -159,8 +159,8 @@ function civicrm_setup_instance(string $adminPath, bool $civicrmUpgrade): \Civi\
   $model->templateCompilePath = implode(DIRECTORY_SEPARATOR, [JPATH_SITE, 'media', 'civicrm', 'templates_c']);
   $model->lang = 'en_US'; /* Joomla installer historically only did `civicrm_data.mysql`. Should fix this... */
 
-  if ($civicrmUpgrade) {
-    require_once $setup->getModel()->settingsPath;
+  if (is_readable($model->settingsPath)) {
+    require_once $model->settingsPath;
     if (defined('CIVICRM_DSN')) {
       $civiDSNParts = DB::parseDSN(CIVICRM_DSN);
       $model->db['username'] = $civiDSNParts['username'];
@@ -172,13 +172,13 @@ function civicrm_setup_instance(string $adminPath, bool $civicrmUpgrade): \Civi\
       $model->db['database'] = $civiDSNParts['database'];
     }
     if (defined('CIVICRM_SITE_KEY')) {
-      $setup->getModel()->siteKey = CIVICRM_SITE_KEY;
+      $model->siteKey = CIVICRM_SITE_KEY;
     }
     if (defined('CIVICRM_CRED_KEYS')) {
-      $setup->getModel()->credKeys = explode(' ', CIVICRM_CRED_KEYS);
+      $model->credKeys = explode(' ', CIVICRM_CRED_KEYS);
     }
     if (defined('CIVICRM_SIGN_KEYS')) {
-      $setup->getModel()->signKeys = explode(' ', CIVICRM_SIGN_KEYS);
+      $model->signKeys = explode(' ', CIVICRM_SIGN_KEYS);
     }
   }
 
@@ -186,39 +186,34 @@ function civicrm_setup_instance(string $adminPath, bool $civicrmUpgrade): \Civi\
 }
 
 /**
+ * @param \Civi\Setup $setup The instance to check for upgrade.
  * @return bool
  *   TRUE if this installation operation is actually an upgrade.
  */
-function civicrm_detect_upgrade(): bool {
-  global $adminPath;
-  $configFile = $adminPath . DIRECTORY_SEPARATOR . 'civicrm.settings.php';
-  $jConfig = new JConfig();
-  $database = $jConfig->db;
-
-  if (is_readable($configFile)) {
-    require_once $configFile;
-
-    if (defined("CIVICRM_DSN")) {
-      if (!class_exists('DB')) {
-        require_once 'DB.php';
-      }
-      $civiDSNParts = DB::parseDSN(CIVICRM_DSN);
-      $database = $civiDSNParts['database'];
-    }
-  }
-
-  if (version_compare(JVERSION, '4.0', 'ge')) {
-    $db = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
-  }
-  else {
-    $db = JFactory::getDbo();
-  }
-  $db->setQuery(' SELECT count( * )
+function civicrm_detect_upgrade($setup): bool {
+  $dbQuery = ' SELECT count( * )
 FROM information_schema.tables
 WHERE table_name LIKE "civicrm_domain"
-AND table_schema = "' . $database . '" ');
+AND table_schema = "' . $setup->getModel()->db['database'] . '" ';
+  $dbResult = 0;
 
-  $civicrmUpgrade = ($db->loadResult() == 0) ? FALSE : TRUE;
+  // use CiviCRM database client and credentials if possible, as we are querying the CiviCRM database (via information_schema)
+  if (defined('CIVICRM_DSN')) {
+    CRM_Core_DAO::init(CIVICRM_DSN);
+    $dbResult = CRM_Core_DAO::singleValueQuery($dbQuery);
+  }
+  else {
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $db = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+    }
+    else {
+      $db = JFactory::getDbo();
+    }
+    $db->setQuery($dbQuery);
+    $dbResult = $db->loadResult();
+  }
+
+  $civicrmUpgrade = ($dbResult == 0) ? FALSE : TRUE;
   return $civicrmUpgrade;
 }
 


### PR DESCRIPTION
This simultaneously fixes [joomla#60](https://lab.civicrm.org/dev/joomla/-/work_items/60) and [core#6320](https://lab.civicrm.org/dev/core/-/work_items/6320), both caused by failure to detect an upgrade scenario during setup.

Both issues are caused by the fact that the query to detect the presence (or otherwise) of the `civicrm_domain` table in `civicrm_detect_upgrade()` fails if the CiviCRM and CMS databases are different and therefore have different credentials / user access.

Before
-------

Upgrades are treated as new installations if the database user for the CMS (Joomla!) database has no privileges to access the CiviCRM database (e.g. because the databases are different).

This causes several issues, such as:
- `CIVICRM_DSN` and other key settings are not copied across in the `civicrm.settings.php` files, i.e. [#47](https://lab.civicrm.org/dev/joomla/-/work_items/47) is not fixed.
- Some permissions keep getting reset ([core#6320](https://lab.civicrm.org/dev/core/-/work_items/6320)).
- A full set of unwanted `civicrm_XXX` tables keep getting created in the CMS database.

And possibly others I've not noticed.

After
-----

Upgrades are correctly detected, by using the CiviCRM database client to access the `information_schema`, instead of the CMS database client, as appropriate.

All of the above problems go away.

Notes
------

This PR also changes the logic so that existing settings are copied from `civicrm.settings.php` as long as that file is readable, irrespective of whether it is an upgrade or not. This makes the behaviour of `civicrm_setup_instance()` consistent with `civicrm_detect_upgrade()`, and feels more appropriate. The rationale being, if someone has edited the settings file, you'd like to preserve this in any case.

There are a number of other incidental code tidy-ups and improvements. For example, only doing the work of parsing the settings file to determine the database names once.

To achieve this, the order of calls to `civicrm_setup_instance()` and `civicrm_detect_upgrade()` is swapped so that autoloading occurs first.